### PR TITLE
Add inherited linker flag and presentation of dropin

### DIFF
--- a/BraintreeTest.xcodeproj/project.pbxproj
+++ b/BraintreeTest.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 					"\"UIKit\"",
 					"-weak_framework",
 					"\"PassKit\"",
+					"$(inherited)",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "BraintreeTest/BraintreeTest-Bridging-Header.h";
@@ -420,6 +421,7 @@
 					"\"UIKit\"",
 					"-weak_framework",
 					"\"PassKit\"",
+					"$(inherited)",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "BraintreeTest/BraintreeTest-Bridging-Header.h";

--- a/BraintreeTest/ViewController.swift
+++ b/BraintreeTest/ViewController.swift
@@ -28,6 +28,8 @@ class ViewController: UIViewController, BTDropInViewControllerDelegate {
         let dropInViewController = brainTree!.dropInViewControllerWithDelegate(self);
         
         dropInViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Cancel, target: self, action: "userDidCancelPayment")
+        let navigationController = UINavigationController(rootViewController: dropInViewController)
+        self.presentViewController(navigationController, animated: true, completion: nil)
     }
     
     func userDidCancelPayment() {


### PR DESCRIPTION
`pod install` prints this warning:

```
[!] The `BraintreeTest [Debug]` target overrides the `OTHER_LDFLAGS` build setting defined in `Pods/Target Support Files/Pods/Pods.debug.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.
```
